### PR TITLE
Fix SignInModal text class typo

### DIFF
--- a/src/components/component/SignInModal.tsx
+++ b/src/components/component/SignInModal.tsx
@@ -100,7 +100,7 @@ export default function SignInModal({ isOpen, onClose }: Readonly<SignInModalPro
                         {isLogin ? "Sign In" : "Sign Up"}
                     </button>
                 </form>
-                <p className="test-sm tet-center pt-2">
+                <p className="text-sm text-center pt-2">
                     {isLogin ? "Don't have an account?" : "Already have an account?"}{" "} 
                     <button className="text-blue-600 cursor-pointer" onClick={() => setIsLogin(!isLogin)}>
                         {isLogin ? "Sign Up" : "Sign In"}


### PR DESCRIPTION
## Summary
- fix typo in the `<p>` element classes in `SignInModal`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435551ce088330bc52f4f1844c6bc6