### PR TITLE
Add Jest setup and MoodPickerComponent test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testEnvironment: 'jest-environment-jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.13",
@@ -31,6 +32,12 @@
     "eslint-config-next": "15.3.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.2.9",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.11",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/user-event": "^14.5.2",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/src/components/component/__tests__/MoodPickerComponent.test.tsx
+++ b/src/components/component/__tests__/MoodPickerComponent.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MoodPickerComponent from '../MoodPickerComponent';
+
+describe('MoodPickerComponent', () => {
+  it('calls onMoodSelect with the selected mood label', async () => {
+    const onMoodSelect = jest.fn();
+    render(<MoodPickerComponent selectedMood={null} onMoodSelect={onMoodSelect} />);
+    const moodButton = screen.getByRole('button', { name: /smile/i });
+    await userEvent.click(moodButton);
+    expect(onMoodSelect).toHaveBeenCalledWith('Smile');
+  });
+});


### PR DESCRIPTION
## Summary
- add jest config using next/jest
- add jest setup file
- add MoodPickerComponent test for onMoodSelect
- expose `npm test` script
- include testing dependencies in package.json

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843555457748330981e4c2c4724fff0